### PR TITLE
fix: when stdout is not a TTY, updates to the UI cause scrolling

### DIFF
--- a/src/virtual-console.ts
+++ b/src/virtual-console.ts
@@ -83,8 +83,11 @@ export class VirtualConsole {
 
     // height is one less than rows, because if you print to the last line, the console usually adds a newline
     resize() {
-        this.width = process.stdout.columns;
-        this.height = process.stdout.rows - 1;
+        // see https://github.com/kamiyo/multi-progress-bars/issues/7    
+        const stdout = process.stdout.isTTY ? process.stdout : process.stderr;
+
+        this.width = stdout.columns;
+        this.height = stdout.rows - 1;
     }
 
     gotoBottom() {


### PR DESCRIPTION
This PR updates virtual-console.ts to use stderr for console sizing, if stdout is not a TTY.

Fixes #7