### PR TITLE
fix: virtual-console overrides console.log, even if stdout is not a TTY

### DIFF
--- a/src/virtual-console.ts
+++ b/src/virtual-console.ts
@@ -57,13 +57,13 @@ export class VirtualConsole {
             this.upsertProgress = this.upsertProgressTop;
             this.writeLines = this.writeLinesTop;
             this.refresh = this.refreshTop;
-            this.log = this.logTop;
+            this.log = process.stdout.isTTY ? this.logTop : this.originalConsole.log;
             this.done = this.cleanup;
         } else {
             this.upsertProgress = this.upsertProgressBottom;
             this.writeLines = this.writeLinesBottom;
             this.refresh = this.refreshBottom;
-            this.log = this.logBottom;
+            this.log = process.stdout.isTTY ? this.logBottom : this.originalConsole.log;
             this.done = this.gotoBottom;
         }
         this.warn = this.log;


### PR DESCRIPTION
Fixes #10