### PR TITLE
Fix lost this context in resize event handler

### DIFF
--- a/src/virtual-console.ts
+++ b/src/virtual-console.ts
@@ -52,7 +52,9 @@ export class VirtualConsole {
         this.width = this.stream.columns;
         this.height = this.stream.rows;
 
-        this.stream.on('resize', this.resize);
+        this.stream.on('resize', () => {
+            this.resize();
+        });
 
         this.progressHeight = 0;
         this.progressBuffer = [];


### PR DESCRIPTION
Resize function has a broken this context right now. It was not an issue in previous versions because stdout was used directly
```
this.width = stdout.columns;
this.height = stdout.rows - 1;
```
And now, when `this.stream` is used, library crashes on resize

```
this.width = this.stream.columns;
this.height = this.stream.rows;
```