### PR TITLE
chore: use `mjs` rather than `es.js` for ESModule build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "4.0.1",
   "description": "Multiple progress bars with option for indefinite spinners",
   "main": "dist/multi-progress-bars.cjs.js",
-  "module": "dist/multi-progress-bars.es.js",
+  "module": "dist/multi-progress-bars.mjs",
   "exports": {
     ".": {
       "require": "./dist/multi-progress-bars.cjs.js",
-      "default": "./dist/multi-progress-bars.es.js"
+      "default": "./dist/multi-progress-bars.mjs"
     }
   },
   "type": "commonjs",


### PR DESCRIPTION
Due to the `"type": "commonjs"` in the package.json, webpack will assume that any `.js` file is in CommonJS module format. We can address this by instead using `.mjs` for ESModule build output.  This is the standard extension, it seems [1].

[1] https://stackoverflow.com/a/57492606/5270773